### PR TITLE
ArrayAccess

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -12,11 +12,11 @@ include "MyCalc.php";
 $tf = new Testify("MyCalc Test Suite");
 
 $tf->beforeEach(function($tf){
-	$tf->data->calc = new MyCalc(10);
+	$tf["calc"] = new MyCalc(10);
 });
 
 $tf->test("Testing the add() method", function($tf){
-	$calc = $tf->data->calc;
+	$calc = $tf["calc"];
 	
 	$calc->add(4);
 	$tf->assert($calc->result() == 14);
@@ -26,7 +26,7 @@ $tf->test("Testing the add() method", function($tf){
 });
 
 $tf->test("Testing the mul() method", function($tf){
-	$calc = $tf->data->calc;
+	$calc = $tf["calc"];
 	
 	$calc->mul(1.5);
 	$tf->assertEqual($calc->result(),15);

--- a/examples/example2.php
+++ b/examples/example2.php
@@ -13,15 +13,15 @@ $tf = new Testify("A bit more advanced test suite");
 
 $tf->beforeEach(function($tf){
 	
-	// Use the data property to share variables across tests
+	// Use $tf like an array to share variables across tests
 	
-	$tf->data->arr = array('a','b','c','d','e','f');
+	$tf["arr"] = array('a','b','c','d','e','f');
 	
 });
 
 $tf->test("Testing Array Pop", function($tf){
 
-	$arr = &$tf->data->arr;
+	$arr = $tf["arr"];
 	
 	$tf->assertEqual(array_pop($arr),'f');
 	$tf->assertEqual(array_pop($arr),'e');
@@ -34,7 +34,7 @@ $tf->test("Testing In Array", function($tf){
 
 	// beforeEach has restored the array
 
-	$arr = &$tf->data->arr;
+	$arr = $tf["arr"];
 	
 	$tf->assertInArray('a',$arr);
 	$tf->assertInArray('b',$arr);

--- a/testify/testify.class.php
+++ b/testify/testify.class.php
@@ -5,14 +5,14 @@
  *
  * This is the main class of the framework. Use it like this:
  * 
- * @version		0.3
+ * @version		0.4
  * @author		Martin Angelov
  * @link		http://tutorialzine.com/testify/
  * @throws		TestifyException
  * @license		GPL
  */
 
-class Testify{
+class Testify implements ArrayAccess {
 	
 	private $tests = array();
 	private $stack = array();
@@ -26,10 +26,13 @@ class Testify{
 	private $beforeEach = NULL;
 	private $afterEach = NULL;
 	
+	private $storedData = array();
+	
 	/**
 	 * A public object for storing state and other variables across test cases and method calls.
 	 * 
 	 * @var stdClass
+	 * @deprecated
 	 */
 	
 	public $data = NULL;
@@ -251,6 +254,54 @@ class Testify{
 		
 		return $this;
 	}
+	
+	/**
+	 * Stores a variable across test cases and method calls
+	 *
+	 * @param string $offset The identifier
+	 * @param mixed $value The value
+	 */
+	
+	public function offsetSet($offset, $value) {
+		if ($offset === NULL) {
+			$this->storedData[] = $value;
+		} else {
+            $this->storedData[$offset] = $value;
+        }
+    }
+    
+    /**
+     * Returns a stored variable
+     *
+     * @param string $offset The identifier
+     * @return mixed The value or NULL if not defined
+     */
+    
+    public function offsetGet($offset) {
+        return isset($this->storedData[$offset]) ? $this->storedData[$offset] : NULL;
+    }
+    
+    /**
+     * Returns if a variable with the identifier $offset exists
+     *
+     * @param string $offset
+     * @return boolean
+     */
+    
+    public function offsetExists($offset) {
+        return isset($this->container[$offset]);
+    }
+    
+    /**
+     * Unsets the variable with the identifier $offset
+     *
+     * @param string $offset
+     */
+    
+    public function offsetUnset($offset) {
+        unset($this->container[$offset]);
+    }
+
 	
 	/**
 	 * A helper method for recording the results of the assertions in the internal stack.


### PR DESCRIPTION
Implementing ArrayAccess to get a more intuitive way to store variables:
$tf["calc"] = new MyCalc(10);
$calc = $tf["calc"];

Instead of:
$tf->data->calc = new MyCalc(10);
$calc = $tf->data->calc;

$tf->data is still there for backward compatibility, but set to deprecated.
