### PR TITLE
Named tests, wider layout.

### DIFF
--- a/testify/testify.class.php
+++ b/testify/testify.class.php
@@ -154,8 +154,8 @@ class Testify{
 	 * @return boolean
 	 */
 	
-	public function assert($arg){
-		return $this->recordTest($arg == true);
+	public function assert($arg, $test_name = ''){
+		return $this->recordTest($arg == true, $test_name);
 	}
 	
 	/**
@@ -165,8 +165,8 @@ class Testify{
 	 * @return boolean
 	 */
 	
-	public function assertFalse($arg){
-		return $this->recordTest($arg == false);
+	public function assertFalse($arg, $test_name = ''){
+		return $this->recordTest($arg == false, $test_name);
 	}
 	
 	/**
@@ -177,8 +177,8 @@ class Testify{
 	 * @return boolean
 	 */
 	
-	public function assertEqual($arg1,$arg2){
-		return $this->recordTest($arg1 == $arg2);
+	public function assertEqual($arg1,$arg2, $test_name = ''){
+		return $this->recordTest($arg1 == $arg2, $test_name);
 	}
 	
 	/**
@@ -189,8 +189,8 @@ class Testify{
 	 * @return boolean
 	 */
 	
-	public function assertIdentical($arg1,$arg2){
-		return $this->recordTest($arg1 === $arg2);
+	public function assertIdentical($arg1,$arg2, $test_name = ''){
+		return $this->recordTest($arg1 === $arg2, $test_name);
 	}
 	
 	/**
@@ -201,8 +201,8 @@ class Testify{
 	 * @return boolean
 	 */
 	
-	public function assertInArray($arg, Array $arr){
-		return $this->recordTest( in_array($arg, $arr));
+	public function assertInArray($arg, Array $arr, $test_name = ''){
+		return $this->recordTest( in_array($arg, $arr), $test_name);
 	}
 	
 	/**
@@ -213,8 +213,8 @@ class Testify{
 	 * @return boolean
 	 */
 	
-	public function assertNotInArray($arg, Array $arr){
-		return $this->recordTest( !in_array($arg, $arr));
+	public function assertNotInArray($arg, Array $arr, $test_name = ''){
+		return $this->recordTest( !in_array($arg, $arr), $test_name);
 	}
 	
 	/**
@@ -259,7 +259,7 @@ class Testify{
 	 * @return boolean
 	 */
 	
-	private function recordTest($pass){
+	private function recordTest($pass, $test_name = ''){
 		
 		if(	!array_key_exists($this->currentTestCase, $this->stack) ||
 			!is_array($this->stack[$this->currentTestCase])){
@@ -275,6 +275,7 @@ class Testify{
 		
 		$result = $pass ? "pass" : "fail";
 		$this->stack[$this->currentTestCase]['tests'][] = array(
+			"name" => $test_name,
 			"type"		=> $bt[1]['function'],
 			"result"	=> $result,
 			"line"		=> $bt[1]['line'],

--- a/testify/testify.report.php
+++ b/testify/testify.report.php
@@ -86,7 +86,7 @@
         	ul{
         		list-style:none;
         		font-size:19px;
-        		width: 430px;
+        		width: 800px;
         		margin: 10px auto 80px;
         	}
         	
@@ -116,7 +116,7 @@
         	
         	li span.type{
         		display:inline-block;
-        		width:200px;
+        		width:600px;
         	}
         	
         	div.message{
@@ -203,7 +203,11 @@
 						foreach ($case['tests'] as $test){ ?>
 							
 							<li>
-								<span class="type <?php echo $test['result']?>"><?php echo $test['type']?>()</span>
+								<span class="type <?php echo $test['result']?>">
+                                    <?php 
+                                        echo $test['name'] === '' ? $test['type'].'()' : $test['name'];
+                                    ?>
+                                </span>
 								<span class="line">line <?php echo $test['line']?></span>
 								<span class="file"><?php echo $test['file']?></span>
 								<div class="source"><?php echo htmlspecialchars($test['source'])?></div>
@@ -219,7 +223,7 @@
 		  		
 	  	</div>
 	  	
-        <footer> Powered by <a href="http://tutorialzine.com/projects/testify/">Testify</a> framework</footer>
+        <footer> Powered by <a href="http://tutorialzine.com/projects/testify/" target="_blank">Testify</a> framework</footer>
         
     </body>
 </html>


### PR DESCRIPTION
I added support for named tests. If supplied, the name of the test will be displayed in place of the type of the test. The parameter is optionnal, so it won't break anything.

I modified the CSS to make the content wider to accomodate longer test names and for a better look in general.

The link to the Testify homepage will now open in a different tab, as all external links should do.
